### PR TITLE
Updating/Cleaning up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,9 @@ MAINTAINER OpenZipkin "http://zipkin.io/"
 ENV ZIPKIN_JAVA_VERSION 0.9.3
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 
-VOLUME /tmp
-RUN curl -SL $ZIPKIN_REPO/io/zipkin/java/zipkin-server/$ZIPKIN_JAVA_VERSION/zipkin-server-$ZIPKIN_JAVA_VERSION-exec.jar > zipkin-server.jar
-
-RUN unzip zipkin-server.jar
+RUN curl -SL $ZIPKIN_REPO/io/zipkin/java/zipkin-server/$ZIPKIN_JAVA_VERSION/zipkin-server-$ZIPKIN_JAVA_VERSION-exec.jar > zipkin-server.jar && \ 
+    unzip zipkin-server.jar && \
+    rm zipkin-server.jar
 
 EXPOSE 9411
 


### PR DESCRIPTION
1. Remove the VOLUME /tmp line (don't really need Docker creating volumes)
2. Merge the 2 RUN commands into one. (reduces the number of committed layers).
   a. Remove the zipkin-server.jar (we don't need this since we just unzipped the contents).

Should make the Docker image smaller.
