### PR TITLE
Removes double-version management in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,22 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 #
-
-FROM openzipkin/zipkin-base:base-1.40.1
-
+FROM openzipkin/jre-full:1.8.0_72
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-ENV ZIPKIN_JAVA_VERSION 0.20.1
+RUN apk add --update --no-cache curl
+
+ENV ZIPKIN_REPO https://jcenter.bintray.com
+ENV ZIPKIN_VERSION 0.20.1
+
+# Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 
-RUN curl -SL $ZIPKIN_REPO/io/zipkin/java/zipkin-server/$ZIPKIN_JAVA_VERSION/zipkin-server-$ZIPKIN_JAVA_VERSION-exec.jar > zipkin-server.jar && \ 
+# Add environment settings for supported storage types
+COPY zipkin/ /zipkin/
+WORKDIR /zipkin
+
+RUN curl -SL $ZIPKIN_REPO/io/zipkin/java/zipkin-server/$ZIPKIN_VERSION/zipkin-server-$ZIPKIN_VERSION-exec.jar > zipkin-server.jar && \
     unzip zipkin-server.jar && \
     rm zipkin-server.jar
 

--- a/zipkin/.cassandra_profile
+++ b/zipkin/.cassandra_profile
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
+  if [[ -z $STORAGE_PORT_9042_TCP_ADDR ]]; then
+    echo "** ERROR: You need to link with a Cassandra container as 'storage' or specify CASSANDRA_CONTACT_POINTS env var."
+    echo "STORAGE_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra contact points."
+    exit 1
+  fi
+  CASSANDRA_CONTACT_POINTS=$STORAGE_PORT_9042_TCP_ADDR
+fi
+
+export CASSANDRA_CONTACT_POINTS
+echo "Cassandra contact points: $CASSANDRA_CONTACT_POINTS"

--- a/zipkin/.mysql_profile
+++ b/zipkin/.mysql_profile
@@ -1,0 +1,17 @@
+#!/bin/sh
+if [[ -z $MYSQL_HOST ]]; then
+  if [[ -z $STORAGE_PORT_3306_TCP_ADDR ]]; then
+    echo "** ERROR: You need to link with a MySQL container as 'storage' or specify MYSQL_HOST env var."
+    echo "STORAGE_PORT_3306_TCP_ADDR (container link) or MYSQL_HOST should contain a MySQL hostname."
+    exit 1
+  fi
+  MYSQL_HOST=$STORAGE_PORT_3306_TCP_ADDR
+  # When there's a container named "mysql", MYSQL_PORT will have a value like tcp://172.17.0.2:3306
+  export MYSQL_PORT=3306
+fi
+
+export MYSQL_HOST
+export MYSQL_USER=${MYSQL_USER:=zipkin}
+export MYSQL_PASS=${MYSQL_PASS:=zipkin}
+
+echo "MySQL host: $MYSQL_HOST"


### PR DESCRIPTION
Previously, we always had to update the versions twice in the
Dockerfile. This caused indirection and maintenance as the files
included are relatively static. By squashing this, we get a single
version, and also the ability to add support for things like mem or
elasticsearch more easily.
