### PR TITLE
Renames docker image to zipkin, as it isn't ambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 [![Build Status](https://travis-ci.org/openzipkin/docker-zipkin-java.svg)](https://travis-ci.org/openzipkin/docker-zipkin-java)
-[![zipkin-java](https://quay.io/repository/openzipkin/zipkin-java/status "zipkin-java")](https://quay.io/repository/openzipkin/zipkin-java)
+[![zipkin](https://quay.io/repository/openzipkin/zipkin/status "zipkin")](https://quay.io/repository/openzipkin/zipkin)
 
-# docker-zipkin-java
+# docker-zipkin
 
 This repository contains the Docker build definition and release process for
-[openzipkin/zipkin-java](https://github.com/openzipkin/zipkin-java), a native
-java port of zipkin, which was historically written in scala+finagle.
+[openzipkin/zipkin](https://github.com/openzipkin/zipkin).
 
 Automatically built images are available on Quay.io
-as [quay.io/openzipkin/zipkin-java](https://quay.io/repository/openzipkin/zipkin-java), and are mirrored to
-Docker Hub as [openzipkin/zipkin-java](https://hub.docker.com/r/openzipkin/zipkin-java/).
+as [quay.io/openzipkin/zipkin](https://quay.io/repository/openzipkin/zipkin), and are mirrored to
+Docker Hub as [openzipkin/zipkin](https://hub.docker.com/r/openzipkin/zipkin/).
 
 ## Running
 
@@ -21,7 +20,7 @@ See the ui at (docker ip):8080
 In the ui - click zipkin-server, then click "Find Traces".
 
 ## Configuration
-Configuration is via environment variables, defined by [zipkin-server](https://github.com/openzipkin/zipkin-java/blob/master/zipkin-server/README.md).
+Configuration is via environment variables, defined by [zipkin-server](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md).
 
 In docker, the following can also be set:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,7 @@
 # Releasing a New Version
 
-This document describes how to release a new Docker image for Java Zipkin
-backend. The images are built automatically on [quay.io](https://quay.io) and
-mirrored to Docker Hub.
+This document describes how to release a new Docker image for Zipkin. The image
+is built automatically on [quay.io](https://quay.io) and mirrored to Docker Hub.
 
 ## Tag structure
 
@@ -27,7 +26,7 @@ level of version pinning they prefer.
 
 1. **There is no step four**
 
-   Congratulations, the intersection of the sets (openzipkin/zipkin-java users) and (Docker
+   Congratulations, the intersection of the sets (openzipkin/zipkin users) and (Docker
    users) can now enjoy the latest and greatest Zipkin Java release!
 
 
@@ -35,14 +34,14 @@ level of version pinning they prefer.
 
 Assume we're releasing `1.4.1`, so you've just pushed the tag `1.4.1`.
 
-* A build of the image `openzipkin/zipkin-java` is triggered on Quay.io, which will build the image and tag it with `1.4.1`.
+* A build of the image `openzipkin/zipkin` is triggered on Quay.io, which will build the image and tag it with `1.4.1`.
   The build is configured to trigger when tags matching `^[0-9]+\.[0-9]+\.[0-9]+$` are pushed.
 * A build of the GitHub repository `openzipkin/docker-zipkin-java` is triggered on Travis CI. The build starts `release.sh`, which
    * Waits for the Quay.io build to start using the Quay.io API to poll for it (timing out after 5 minutes), and then
      waits for it to finish (never timing out). The heuristic used to identify the build we want: it's the latest build
      started for the tag we're building.
    * Syncs the tags `1`, `1.4`, and `latest` to the tag `1.4.1` on Quay.io.
-   * Syncs the tags `1`, `1.4`, `1.4.1` for `zipkin-java` to Docker Hub by pulling them from quay.io using the `docker` CLI and
+   * Syncs the tags `1`, `1.4`, `1.4.1` for `zipkin` to Docker Hub by pulling them from quay.io using the `docker` CLI and
      pushing them to Docker Hub.
    * A friendly message is printed to remind the release manager (HAH! Such words.) about manually testing the release
      and updating the tags in `docker-compose.yml`. This last part could definitely use more automation.

--- a/docker-compose-aws.yml
+++ b/docker-compose-aws.yml
@@ -1,0 +1,25 @@
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+query:
+  build: .
+  environment:
+    - STORAGE_TYPE=mysql
+    - MYSQL_HOST=zipkin1.cwvmcf2mbq7k.us-west-2.rds.amazonaws.com
+    - MYSQL_USER=zipkin
+    - MYSQL_PASS=8WCGBT3eF73
+    - MYSQL_MAX_CONNECTIONS=4
+  ports:
+    - 9410:9410
+    - 9411:9411
+    - 8080:9411

--- a/docker-compose-cassandra.yml
+++ b/docker-compose-cassandra.yml
@@ -20,8 +20,8 @@ services:
     container_name: cassandra
     ports:
       - 9042:9042
-  server:
-    image: openzipkin/zipkin-java:1.1.2
+  zipkin:
+    image: openzipkin/zipkin:1.1.2
     environment:
       - STORAGE_TYPE=cassandra
       # When overriding this value, note the minimum supported version is 2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,14 @@ services:
     container_name: mysql
     ports:
       - 3306:3306
-  server:
-    image: openzipkin/zipkin-java:1.1.2
+  zipkin:
+    image: openzipkin/zipkin:1.1.2
     environment:
       - STORAGE_TYPE=mysql
       - MYSQL_HOST=mysql
       # Uncomment to disable self-tracing
       # - SELF_TRACING_ENABLED=false
-      # More options, such as Kafka here: https://github.com/openzipkin/zipkin-java/blob/master/zipkin-server/README.md#environment-variables
+      # More options, such as Kafka here: https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
     ports:
       # Listen port for the Scribe transport
       - 9410:9410

--- a/release.sh
+++ b/release.sh
@@ -32,7 +32,7 @@ started_at=$($date +%s)
 ## Read input and env
 version="$1"
 # Service images
-image="${IMAGE_NAME:-zipkin-java}"
+image="${IMAGE_NAME:-zipkin}"
 # Remotes, auth
 docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
 quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"


### PR DESCRIPTION
Moving forward, we have a single docker image. Instead of a suffix, we
can standardize on the simple word "zipkin"
